### PR TITLE
graph: backend: elyzor: add an entry point for version of gc

### DIFF
--- a/src/graph/backend/elyzor/include/dnnl_graph_compiler.h
+++ b/src/graph/backend/elyzor/include/dnnl_graph_compiler.h
@@ -1,11 +1,10 @@
 #ifndef DNNL_GRAPH_COMPILER_H
 #define DNNL_GRAPH_COMPILER_H
-#define DNNL_DLL
-#define DNNL_DLL_EXPORTS
 
 #include <cstddef>
 #include <cstdint>
 #include "dnnl_types.h"
+#include "dnnl_version.h"
 
 /*
  * Public API for integration with third-party graph compilers.
@@ -15,8 +14,31 @@
 extern "C" {
 #endif
 
+// graph compiler's API version following semver
+#define DNNL_GC_API_V_MAJOR 0
+#define DNNL_GC_API_V_MINOR 1
+#define DNNL_GC_API_V_PATCH 0
+#ifdef DNNL_VERSION_HASH
+#define DNNL_GC_API_V_HASH DNNL_VERSION_HASH
+#else
+#define DNNL_GC_API_V_HASH "N/A"
+#endif
+
 struct dnnl_graph_compiler;
 struct dnnl_graph_compiler_executable;
+
+struct dnnl_graph_compiler_version {
+    struct version {
+        size_t major;
+        size_t minor;
+        size_t patch;
+        const char *hash;
+    };
+    // version of the gc API that was used to compile gc
+    version api_version;
+    // version of the graph compiler itself
+    version gc_version;
+};
 
 struct dnnl_graph_compiler_context {
     uint32_t num_threads;
@@ -32,6 +54,9 @@ struct dnnl_graph_compiler_tensor {
     size_t *dims;
     void *data;
 };
+
+DNNL_API const dnnl_graph_compiler_version *dnnl_graph_compiler_get_version(
+        void);
 
 DNNL_API dnnl_status_t dnnl_graph_compiler_create(
         const struct dnnl_graph_compiler_context *ctx,

--- a/src/graph/backend/elyzor/include/dnnl_graph_compiler.h
+++ b/src/graph/backend/elyzor/include/dnnl_graph_compiler.h
@@ -1,5 +1,7 @@
 #ifndef DNNL_GRAPH_COMPILER_H
 #define DNNL_GRAPH_COMPILER_H
+#define DNNL_DLL
+#define DNNL_DLL_EXPORTS
 
 #include <cstddef>
 #include <cstdint>
@@ -34,10 +36,19 @@ struct dnnl_graph_compiler_version {
         size_t patch;
         const char *hash;
     };
-    // version of the gc API that was used to compile gc
+    // version of the gc API that was used to compile gc,
+    // we only bump it if the API in this file changes
     version api_version;
-    // version of the graph compiler itself
+    // version of the graph compiler itself, we only bump it if
+    // the core graph compiler releases a new version (with new
+    // compiling features, etc) that does not necessarily change
+    // the API in this file
     version gc_version;
+    // Why having two versions?
+    // The versions are bumped independently, so we want to know both versions of the '.so':
+    //     1. API version - to check whether it's compatible at all with the current oneDNN version.
+    //     2. GC version - to know which features/compilation patterns are supported in order to
+    //        dispatch backend's logic based on this information (register certain patterns or not)
 };
 
 struct dnnl_graph_compiler_context {

--- a/src/graph/backend/elyzor/include/dnnl_graph_compiler.h
+++ b/src/graph/backend/elyzor/include/dnnl_graph_compiler.h
@@ -31,9 +31,9 @@ struct dnnl_graph_compiler_executable;
 
 struct dnnl_graph_compiler_version {
     struct version {
-        size_t major;
-        size_t minor;
-        size_t patch;
+        uint8_t major;
+        uint8_t minor;
+        uint8_t patch;
         const char *hash;
     };
     // version of the gc API that was used to compile gc,


### PR DESCRIPTION
This PR adds a structure `dnnl_graph_compiler_version` that contains two versions:
1. The version of the GC API (defined by oneDNN)
2. The version of the graph compiler itself (defined in the graph compiler)

As well as a getter function for that:
```cpp
DNNL_API const dnnl_graph_compiler_version *dnnl_graph_compiler_get_version(
        void);
```
(this function follows [oneDNN's logic](https://github.com/intel-ai/oneDNN/blob/cc1ed10df3cb57decef3867b09d6dd2c25f7cbcf/include/oneapi/dnnl/dnnl_common.h#L163) and returns a version itself instead of a status)

Possible implementation at the graph compiler side:
```cpp
// graph_compiler : dnnl_graph_compiler.cpp
DNNL_API const dnnl_graph_compiler_version *dnnl_graph_compiler_get_version(
        void) {
    static const dnnl_graph_compiler_version ver
            = {
                .api_version = {DNNL_GC_API_V_MAJOR, DNNL_GC_API_V_MINOR, // version defined in oneDNN
                                DNNL_GC_API_V_PATCH, DNNL_GC_API_V_HASH},
                .gc_version = {GC_VERSION_MAJOR, GC_VERSION_MINOR, // version defined in gc implementation
                               GC_VERSION_PATCH, GC_VERSION_HASH}};
    return &ver;
}
```

#### Why two versions?

This in theory should ease maintaining as we now define two versions:
1. GC version - which features gc core contains
2. GC API version - with which oneDNN version we can use this `.so`

So there can potentially be a situation like this: we have a very old oneDNN version defining gc API 0.1.0 when the actual API version is 0.2.0. Then we have two versions of GC core (0.5.0 - implements feature A; 0.4.2 - doesn't implement feature A), we can easily integrate the feature A to the old oneDNN and the new one by compiling GC with both versions of the API. If our version structure defines two versions it's easier to check compatibility then:
1. Build1: `libgraph_compiler.so` API version: 0.1.0, GC version: 0.5.0 <-- can be used with old oneDNN
2. Build2: `libgraph_compiler.so` API version: 0.2.0, GC version: 0.5.0 <-- can be used with new oneDNN

I don't have a strong preference here though, if needed, we can remove `api_version` from the structure.
