### PR TITLE
graph: backend: elyzor: fill input graph's tensors with shapes before converting to json

### DIFF
--- a/src/graph/backend/elyzor/elyzor_partition_impl.hpp
+++ b/src/graph/backend/elyzor/elyzor_partition_impl.hpp
@@ -27,8 +27,6 @@
 #include "elyzor_backend.hpp"
 #include "utils.hpp"
 
-class test_elyzor_partition_impl_t;
-
 namespace dnnl {
 namespace impl {
 namespace graph {
@@ -36,7 +34,6 @@ namespace elyzor {
 
 class elyzor_partition_impl_t : public partition_impl_t {
     friend class elyzor_backend_t;
-    friend class ::test_elyzor_partition_impl_t;
 
 public:
     elyzor_partition_impl_t(graph::engine_kind_t engine_kind,
@@ -107,6 +104,13 @@ public:
     }
 
     std::string get_name() const { return pname_; }
+
+#ifndef NDEBUG
+    // get protected 'copied_ops_' field, should only be used in testing
+    std::vector<std::shared_ptr<graph::op_t>> get_copied_ops() {
+        return copied_ops_;
+    }
+#endif
 
 protected:
     bool is_init_ = false;

--- a/src/graph/backend/elyzor/elyzor_partition_impl.hpp
+++ b/src/graph/backend/elyzor/elyzor_partition_impl.hpp
@@ -27,6 +27,8 @@
 #include "elyzor_backend.hpp"
 #include "utils.hpp"
 
+class test_elyzor_partition_impl_t;
+
 namespace dnnl {
 namespace impl {
 namespace graph {
@@ -34,6 +36,7 @@ namespace elyzor {
 
 class elyzor_partition_impl_t : public partition_impl_t {
     friend class elyzor_backend_t;
+    friend class ::test_elyzor_partition_impl_t;
 
 public:
     elyzor_partition_impl_t(graph::engine_kind_t engine_kind,

--- a/tests/gtests/graph/unit/backend/CMakeLists.txt
+++ b/tests/gtests/graph/unit/backend/CMakeLists.txt
@@ -17,3 +17,4 @@
 add_subdirectory(fake)
 add_subdirectory(dnnl)
 add_subdirectory(graph_compiler)
+add_subdirectory(elyzor)

--- a/tests/gtests/graph/unit/backend/elyzor/CMakeLists.txt
+++ b/tests/gtests/graph/unit/backend/elyzor/CMakeLists.txt
@@ -1,0 +1,55 @@
+#===============================================================================
+# Copyright 2021-2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+if(NOT ONEDNN_EXPERIMENTAL_ELYZOR_BACKEND)
+    return()
+endif()
+
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
+    get_property(CCXX_NOWARN_FLAGS GLOBAL PROPERTY ELYZOR_CCXX_NOWARN_FLAGS)
+    append(CMAKE_CCXX_NOWARN_FLAGS ${CCXX_NOWARN_FLAGS})
+endif()
+
+if(CMAKE_BASE_NAME MATCHES "(icx|icpx)")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations -Wno-unused-variable -Wno-unused-function")
+    append_host_compiler_options(CMAKE_CXX_FLAGS "-Wno-deprecated-declarations -Wno-unused-variable -Wno-unused-function")
+endif()
+
+append(CMAKE_CXX_FLAGS "${CMAKE_CCXX_NOWARN_FLAGS}")
+append_host_compiler_options(CMAKE_CXX_FLAGS "${DPCPP_CXX_NOWARN_FLAGS}")
+
+set(OBJ_LIB graph_unit_test_elyzor_backend)
+
+file(GLOB_RECURSE TEST_SRC
+${CMAKE_CURRENT_SOURCE_DIR}/*.cpp
+)
+
+add_library(${OBJ_LIB} OBJECT ${TEST_SRC})
+
+include_directories_with_host_compiler(${OBJ_LIB}
+    PRIVATE
+    ${PROJECT_SOURCE_DIR}/tests/gtests/graph # gtest related headers
+    ${PROJECT_SOURCE_DIR}/src/
+    ${CMAKE_CURRENT_SOURCE_DIR}/core
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/reference
+    ${PROJECT_SOURCE_DIR}/src/cpu/x64
+    )
+
+set_property(GLOBAL APPEND PROPERTY GRAPH_UNIT_TEST_DEPS
+    $<TARGET_OBJECTS:${OBJ_LIB}>)
+
+register_graph_test_suite("test_graph_unit_elyzor_cpu" 
+    "ElyzorGraphTest.*")

--- a/tests/gtests/graph/unit/backend/elyzor/test_compile_execute.cpp
+++ b/tests/gtests/graph/unit/backend/elyzor/test_compile_execute.cpp
@@ -1,0 +1,101 @@
+/*******************************************************************************
+* Copyright 2021-2024 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+#include "backend/elyzor/elyzor_backend.hpp"
+#include "interface/allocator.hpp"
+#include "interface/graph.hpp"
+#include "interface/partition.hpp"
+#include "test_utils.hpp"
+
+#include <gtest/gtest.h>
+
+// Verify that after calling 'elyzor_partition_impl_t::infer_shape' the input shapes
+// are propagated to the 'copied_ops_' field (the one that is used to dump the graph to JSON)
+TEST(ElyzorGraphTest, CompleteInputShapes) {
+    utils::id_generator id_gen;
+    impl::graph_t agraph;
+    impl::dims initial_shapes = {};
+    // constructing a graph providing no shapes
+    construct_mul_quantize_subgraph(&agraph, id_gen, initial_shapes);
+    agraph.finalize();
+
+    // map<tensor_id, input_shape>
+    std::unordered_map<size_t, impl::dims> input_shapes
+            = {{0, {10}}, {1, {10}}};
+    std::unordered_map<size_t, impl::dims> expected_complete_shapes
+            = {{0, {10}}, {1, {10}}, {2, {10}}, {3, {10}}};
+
+    auto &backend_ptr = impl::elyzor::elyzor_backend_t::get_singleton();
+    backend_ptr.get_partitions(agraph, impl::partition_policy::fusion);
+    auto partitions = agraph.get_partitions();
+    for (auto &part : partitions) {
+        std::vector<std::shared_ptr<graph::logical_tensor_t>> inputs_ptr,
+                outputs_ptr;
+        std::vector<const graph::logical_tensor_t *> inputs;
+        std::vector<graph::logical_tensor_t *> outputs;
+        for (auto &lt : part->get_inputs()) {
+            // verify that the input shapes are unknown
+            ASSERT_EQ(lt.ndims, DNNL_GRAPH_UNKNOWN_NDIMS);
+            ASSERT_EQ(lt.dims[0], DNNL_GRAPH_UNKNOWN_DIM);
+
+            auto new_lt = std::make_shared<impl::logical_tensor_t>(
+                    utils::logical_tensor_init(
+                            lt.id, input_shapes[lt.id], lt.data_type));
+            ASSERT_NE(new_lt->ndims, DNNL_GRAPH_UNKNOWN_NDIMS);
+            ASSERT_NE(new_lt->dims[0], DNNL_GRAPH_UNKNOWN_DIM);
+
+            inputs_ptr.push_back(new_lt);
+            inputs.push_back(new_lt.get());
+        }
+        for (auto &lt : part->get_outputs()) {
+            // verify that the output shapes are unknown
+            ASSERT_EQ(lt.ndims, DNNL_GRAPH_UNKNOWN_NDIMS);
+            ASSERT_EQ(lt.dims[0], DNNL_GRAPH_UNKNOWN_DIM);
+            auto new_lt = std::make_shared<impl::logical_tensor_t>(
+                    utils::logical_tensor_init(lt.id, lt.data_type));
+            ASSERT_EQ(new_lt->ndims, DNNL_GRAPH_UNKNOWN_NDIMS);
+            ASSERT_EQ(new_lt->dims[0], DNNL_GRAPH_UNKNOWN_DIM);
+            outputs_ptr.push_back(new_lt);
+            outputs.push_back(new_lt.get());
+        }
+
+        part->infer_shape(inputs, outputs);
+        // getting the field containing a graph to be converted to JSON
+        auto ops = test_elyzor_partition_impl_t::get_copied_ops(
+                std::static_pointer_cast<impl::elyzor::elyzor_partition_impl_t>(
+                        part));
+        // iterating over the graph and verifying that all the shapes are complete
+        for (auto &op : ops) {
+            for (auto &in_val : op->get_input_values()) {
+                auto lt = in_val->get_logical_tensor();
+                ASSERT_NE(lt.ndims, DNNL_GRAPH_UNKNOWN_NDIMS);
+                ASSERT_NE(lt.dims[0], DNNL_GRAPH_UNKNOWN_DIM);
+                auto &complete_shape = expected_complete_shapes[lt.id];
+                for (size_t i = 0; i < complete_shape.size(); i++) {
+                    ASSERT_EQ(lt.dims[i], complete_shape[i]);
+                }
+            }
+            for (auto &out_val : op->get_output_values()) {
+                auto lt = out_val->get_logical_tensor();
+                ASSERT_NE(lt.ndims, DNNL_GRAPH_UNKNOWN_NDIMS);
+                ASSERT_NE(lt.dims[0], DNNL_GRAPH_UNKNOWN_DIM);
+                auto &complete_shape = expected_complete_shapes[lt.id];
+                for (size_t i = 0; i < complete_shape.size(); i++) {
+                    ASSERT_EQ(lt.dims[i], complete_shape[i]);
+                }
+            }
+        }
+    }
+}

--- a/tests/gtests/graph/unit/backend/elyzor/test_compile_execute.cpp
+++ b/tests/gtests/graph/unit/backend/elyzor/test_compile_execute.cpp
@@ -14,12 +14,16 @@
 * limitations under the License.
 *******************************************************************************/
 #include "backend/elyzor/elyzor_backend.hpp"
+#include "backend/elyzor/elyzor_partition_impl.hpp"
 #include "interface/allocator.hpp"
 #include "interface/graph.hpp"
 #include "interface/partition.hpp"
 #include "test_utils.hpp"
 
 #include <gtest/gtest.h>
+
+// the tests below use getters that are only defined under '!NDEBUG'
+#ifndef NDEBUG
 
 // Verify that after calling 'elyzor_partition_impl_t::infer_shape' the input shapes
 // are propagated to the 'copied_ops_' field (the one that is used to dump the graph to JSON)
@@ -73,9 +77,9 @@ TEST(ElyzorGraphTest, CompleteInputShapes) {
 
         part->infer_shape(inputs, outputs);
         // getting the field containing a graph to be converted to JSON
-        auto ops = test_elyzor_partition_impl_t::get_copied_ops(
-                std::static_pointer_cast<impl::elyzor::elyzor_partition_impl_t>(
-                        part));
+        auto ops = std::static_pointer_cast<
+                impl::elyzor::elyzor_partition_impl_t>(part)
+                           ->get_copied_ops();
         // iterating over the graph and verifying that all the shapes are complete
         for (auto &op : ops) {
             for (auto &in_val : op->get_input_values()) {
@@ -99,3 +103,5 @@ TEST(ElyzorGraphTest, CompleteInputShapes) {
         }
     }
 }
+
+#endif

--- a/tests/gtests/graph/unit/backend/elyzor/test_utils.hpp
+++ b/tests/gtests/graph/unit/backend/elyzor/test_utils.hpp
@@ -1,0 +1,90 @@
+/*******************************************************************************
+* Copyright 2021-2024 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+#ifndef BACKEND_ELYZOR_TEST_UTILS_HPP
+#define BACKEND_ELYZOR_TEST_UTILS_HPP
+
+#include "backend/elyzor/elyzor_partition_impl.hpp"
+#include "interface/graph.hpp"
+
+#include "graph/unit/unit_test_common.hpp"
+#include "graph/unit/utils.hpp"
+
+namespace impl = dnnl::impl::graph;
+namespace utils = dnnl::graph::tests::unit::utils;
+
+using ltsr_vec = std::vector<impl::logical_tensor_t>;
+
+#define DEFINE_DEFAULT_PER_TENSOR_QUANT_ATTR(name) \
+    name.set_attr(graph::op_attr::scales, std::vector<float>({0.12f})); \
+    name.set_attr(graph::op_attr::zps, std::vector<int64_t>({2})); \
+    name.set_attr(graph::op_attr::qtype, std::string("per_tensor")); \
+    name.set_attr(graph::op_attr::axis, (int64_t)0);
+
+class test_elyzor_partition_impl_t {
+public:
+    static std::vector<std::shared_ptr<impl::op_t>> get_copied_ops(
+            std::shared_ptr<impl::elyzor::elyzor_partition_impl_t> part) {
+        return part->copied_ops_;
+    }
+};
+
+inline void construct_mul_quantize_subgraph(graph::graph_t *agraph,
+        utils::id_generator &id_gen, const graph::dims &input_shape,
+        bool is_mixed_precision = false) {
+    bool known_shapes = input_shape.size() != 0;
+    auto dtype = is_mixed_precision ? graph::data_type::bf16
+                                    : graph::data_type::f32;
+
+    dnnl::impl::graph::logical_tensor_t mul_in, smooth_quant_scale, mul_out,
+            quant_out;
+    if (known_shapes) {
+        graph::dims smooth_quant_scales_shape {
+                input_shape[input_shape.size() - 1]};
+        mul_in = utils::logical_tensor_init(
+                id_gen.get_id(), input_shape, dtype);
+        smooth_quant_scale = utils::logical_tensor_init(id_gen.get_id(),
+                smooth_quant_scales_shape, graph::data_type::f32);
+        mul_out = utils::logical_tensor_init(
+                id_gen.get_id(), input_shape, graph::data_type::f32);
+        quant_out = utils::logical_tensor_init(
+                id_gen.get_id(), input_shape, graph::data_type::u8);
+    } else {
+        mul_in = utils::logical_tensor_init(id_gen.get_id(), dtype);
+        smooth_quant_scale = utils::logical_tensor_init(
+                id_gen.get_id(), graph::data_type::f32);
+        mul_out = utils::logical_tensor_init(
+                id_gen.get_id(), graph::data_type::f32);
+        quant_out = utils::logical_tensor_init(
+                id_gen.get_id(), graph::data_type::u8);
+    }
+
+    graph::op_t mul {id_gen.get_id(), graph::op_kind::Multiply, "mul"};
+    mul.set_attr(graph::op_attr::auto_broadcast, std::string("numpy"));
+    graph::op_t quantize {
+            id_gen.get_id(), graph::op_kind::Quantize, "quantize"};
+    DEFINE_DEFAULT_PER_TENSOR_QUANT_ATTR(quantize);
+
+    mul.add_input(mul_in);
+    mul.add_input(smooth_quant_scale);
+    mul.add_output(mul_out);
+    quantize.add_input(mul_out);
+    quantize.add_output(quant_out);
+
+    agraph->add_op(&mul);
+    agraph->add_op(&quantize);
+}
+
+#endif

--- a/tests/gtests/graph/unit/backend/elyzor/test_utils.hpp
+++ b/tests/gtests/graph/unit/backend/elyzor/test_utils.hpp
@@ -16,7 +16,6 @@
 #ifndef BACKEND_ELYZOR_TEST_UTILS_HPP
 #define BACKEND_ELYZOR_TEST_UTILS_HPP
 
-#include "backend/elyzor/elyzor_partition_impl.hpp"
 #include "interface/graph.hpp"
 
 #include "graph/unit/unit_test_common.hpp"
@@ -32,14 +31,6 @@ using ltsr_vec = std::vector<impl::logical_tensor_t>;
     name.set_attr(graph::op_attr::zps, std::vector<int64_t>({2})); \
     name.set_attr(graph::op_attr::qtype, std::string("per_tensor")); \
     name.set_attr(graph::op_attr::axis, (int64_t)0);
-
-class test_elyzor_partition_impl_t {
-public:
-    static std::vector<std::shared_ptr<impl::op_t>> get_copied_ops(
-            std::shared_ptr<impl::elyzor::elyzor_partition_impl_t> part) {
-        return part->copied_ops_;
-    }
-};
 
 inline void construct_mul_quantize_subgraph(graph::graph_t *agraph,
         utils::id_generator &id_gen, const graph::dims &input_shape,


### PR DESCRIPTION
The previous logic of [`elyzor_partition_impl_t::infer_shapes`](https://github.com/kurapov-peter/oneDNN/blob/cc1ed10df3cb57decef3867b09d6dd2c25f7cbcf/src/graph/backend/elyzor/elyzor_partition_impl.cpp#L38) that is called at the [beginning of `compile` method](https://github.com/kurapov-peter/oneDNN/blob/cc1ed10df3cb57decef3867b09d6dd2c25f7cbcf/src/graph/backend/elyzor/elyzor_partition_impl.cpp#L136), went through [each output tensor of each operation](https://github.com/kurapov-peter/oneDNN/blob/cc1ed10df3cb57decef3867b09d6dd2c25f7cbcf/src/graph/backend/elyzor/elyzor_partition_impl.cpp#L82-L109) and filled it with inferred dims. The fact that it was going only through outputs, resulted in that the input tensors of the graph remained with unknown shapes (although they were explicitly provided with the `inputs` argument). 

For gc 1.0 it was fine, since the vector of inputs [was passed together with the graph itself](https://github.com/kurapov-peter/oneDNN/blob/cc1ed10df3cb57decef3867b09d6dd2c25f7cbcf/src/graph/backend/graph_compiler/compiler_partition_impl.cpp#L319-L342), so graph compiler could later deduce missing input shapes. However in case of elyzor, where we're only passing a JSON file with no additional arguments, this results into that the input shapes are not propagated to the compiler, e.g JSON looks like this:
<details><summary>json with unknown input shapes</summary>

```json
{
  "version": "3.5.0",
  "engine_kind": "cpu",
  "fpmath_mode": "strict",
  "input_ports": [ ### those will have unknown shapes
    0,
    1
  ],
  "output_ports": [
    3
  ],
  "graph": [
    {
      "id": 4,
      "name": "mul",
      "kind": "Multiply",
      "attrs": {
        "auto_broadcast": {
          "type": "string",
          "value": "numpy"
        }
      },
      "inputs": [
        {
          "id": 0,
          "dtype": "f32",
          "shape": [
            -9223372036854775808 #### input graph tensors have unknown shapes
          ],
          "stride": [
            -9223372036854775808
          ],
          "layout_type": "undef",
          "property_type": "undef"
        }, 
        {
          "id": 1,
          "dtype": "f32",
          "shape": [
            -9223372036854775808 #### input graph tensors have unknown shapes
          ],
          "stride": [
            -9223372036854775808
          ],
          "layout_type": "undef",
          "property_type": "undef"
        }
      ],
      "outputs": [
        {
          "id": 2,
          "dtype": "f32",
          "shape": [
            10		#### however all the other tensors have proper shapes
          ],
          "stride": [
            1
          ],
          "layout_type": "strided",
          "property_type": "undef"
        }
      ]
    }, 
    {
      "id": 5,
      "name": "quantize",
      "kind": "Quantize",
      "attrs": {
        "axis": {
          "type": "s64",
          "value": 0
        },
        "qtype": {
          "type": "string",
          "value": "per_tensor"
        },
        "zps": {
          "type": "s64[]",
          "value": [
            2
          ]
        },
        "scales": {
          "type": "f32[]",
          "value": [
            0.12
          ]
        }
      },
      "inputs": [
        {
          "id": 2,
          "dtype": "f32",
          "shape": [
            10           #### however all the other tensors have proper shapes
          ],
          "stride": [
            1
          ],
          "layout_type": "strided",
          "property_type": "undef"
        }
      ],
      "outputs": [
        {
          "id": 3,
          "dtype": "u8",
          "shape": [
            10       #### however all the other tensors have proper shapes
          ],
          "stride": [
            1
          ],
          "layout_type": "strided",
          "property_type": "undef"
        }
      ]
    }
  ]
}
```

</details>

The proposed fix is to modify the logic of `infer_shapes` so it would also go through each input tensor that has no producers (considered to be an input tensor of the subgraph) and complete its dims with the dims provided by the `inputs` argument.

#### How this change was tested

I've added a simple sanity-check test for the elyzor backend that verifies that the shapes are propagated to the `copied_ops_` (the field from which we export graph to json) in the [mul_typecast_quantize pattern](https://github.com/oneapi-src/oneDNN/blob/d41918707bbb61f4c16bf1900e14c93ebfa2915d/src/graph/backend/graph_compiler/patterns/misc_pattern.hpp#L36-L47). Not very comprehensive but still something.

Just to check that it doesn't break anything obvious I've applied the same change in `infer_shape` to the existing [graph compiler oneDNN backend](https://github.com/kurapov-peter/oneDNN/blob/cc1ed10df3cb57decef3867b09d6dd2c25f7cbcf/src/graph/backend/graph_compiler/compiler_partition_impl.cpp#L48) locally and ran its complete [test suit](https://github.com/kurapov-peter/oneDNN/tree/dev/tests/gtests/graph/unit/backend/graph_compiler). The tests have passed.