### PR TITLE
graph: backend: elyzor: use oneDNN's ISA traits to determine cpu features

### DIFF
--- a/src/graph/backend/elyzor/target_machine.hpp
+++ b/src/graph/backend/elyzor/target_machine.hpp
@@ -16,35 +16,26 @@
 #ifndef BACKEND_ELYZOR_TARGET_MACHINE_HPP
 #define BACKEND_ELYZOR_TARGET_MACHINE_HPP
 
-// An internal GC's functionality that provides machine flags,
-// assuming all the flags are true for now
-// #include "core/src/compiler/config/context.hpp"
-// #include "runtime/config.hpp"
+#include "cpu/x64/cpu_isa_traits.hpp"
 
 #define REQUIRE_AVX512_BEGIN \
-    if (true) {
-    // if (::dnnl::impl::graph::gc::get_default_context() \
-    //                 ->machine_.cpu_flags_.fAVX512F) {
+    if (dnnl::impl::cpu::x64::cpu().has(Xbyak::util::Cpu::tAVX512F)) {
 #define REQUIRE_VNNI_AMXINT8_BEGIN \
-    if (true) {
-    // if (::dnnl::impl::graph::gc::get_default_context() \
-    //                 ->machine_.cpu_flags_.fAVX512VNNI \
-    //         || ::dnnl::impl::graph::gc::get_default_context() \
-    //                    ->machine_.cpu_flags_.fAVX512AMXINT8) {
+    if (dnnl::impl::cpu::x64::cpu().has(Xbyak::util::Cpu::tAVX512_VNNI) \
+            || (dnnl::impl::cpu::x64::cpu().has(Xbyak::util::Cpu::tAVX512F) \
+                    && dnnl::impl::cpu::x64::cpu().has( \
+                            Xbyak::util::Cpu::tAMX_INT8))) {
 #define REQUIRE_BF16_AMXBF16_BEGIN \
-    if (true) {
-    // if (::dnnl::impl::graph::gc::get_default_context() \
-    //                 ->machine_.cpu_flags_.fAVX512BF16 \
-    //         || ::dnnl::impl::graph::gc::get_default_context() \
-    //                    ->machine_.cpu_flags_.fAVX512AMXBF16) {
+    if (dnnl::impl::cpu::x64::cpu().has(Xbyak::util::Cpu::tAVX512_BF16) \
+            || (dnnl::impl::cpu::x64::cpu().has(Xbyak::util::Cpu::tAVX512F) \
+                    && dnnl::impl::cpu::x64::cpu().has( \
+                            Xbyak::util::Cpu::tAMX_BF16))) {
 #define REQUIRE_AMX_BEGIN \
-    if (true) {
-    // if (dnnl::impl::graph::gc::get_default_context() \
-    //                 ->machine_.cpu_flags_.fAVX512AMXTILE) {
+    if (dnnl::impl::cpu::x64::cpu().has(Xbyak::util::Cpu::tAVX512F) \
+            && dnnl::impl::cpu::x64::cpu().has(Xbyak::util::Cpu::tAMX_TILE)) {
 #define REQUIRE_AMXBF16_BEGIN \
-    if (true){
-    // if (dnnl::impl::graph::gc::get_default_context() \
-    //                 ->machine_.cpu_flags_.fAVX512AMXBF16) {
+    if (dnnl::impl::cpu::x64::cpu().has(Xbyak::util::Cpu::tAVX512F) \
+            && dnnl::impl::cpu::x64::cpu().has(Xbyak::util::Cpu::tAMX_BF16)) {
 #define REQUIRE_AVX512_END }
 #define REQUIRE_VNNI_AMXINT8_END }
 #define REQUIRE_BF16_AMXBF16_END }


### PR DESCRIPTION
Extract available CPU features using [xbyak utils from oneDNN](https://github.com/oneapi-src/oneDNN/blob/1344a14b4160d62a18dcc447a2c0f122f87b5b03/src/cpu/x64/cpu_isa_traits.hpp) instead of [internal graph compiler's functionality](https://github.com/oneapi-src/oneDNN/blob/1344a14b4160d62a18dcc447a2c0f122f87b5b03/src/graph/backend/graph_compiler/core/src/runtime/target_machine.hpp).

In order to detect CPU features, both (gc internal impl and xbyak utils) call `cpuid()` function to populate a bitmask consisting of 4 ints describing features ([`int info[4]` in case of gc internal](https://github.com/oneapi-src/oneDNN/blob/1344a14b4160d62a18dcc447a2c0f122f87b5b03/src/graph/backend/graph_compiler/core/src/runtime/target_machine.cpp#L114-L115) impl and [`int EAX, EBX, ECX, EDX` in case of xbyak utils](https://github.com/oneapi-src/oneDNN/blob/1344a14b4160d62a18dcc447a2c0f122f87b5b03/src/cpu/x64/xbyak/xbyak_util.h#L540-L545)). Then individual bits are checked to determine supported features.

In the comments below I've specified which flag is extracted from which bit, in order to verify that both implementations are identical.