### PR TITLE
graph: backend: elyzor: verify gc API version when loading '.so'

### DIFF
--- a/src/graph/backend/elyzor/compiler_loader.cpp
+++ b/src/graph/backend/elyzor/compiler_loader.cpp
@@ -79,10 +79,8 @@ graph_compiler_loader::graph_compiler_loader() {
         if (!is_supported_api_version(lib_v->api_version)) {
             std::stringstream ss;
             ss << "Unsupported GC API version found in " << DNNL_GC_LIB_NAME
-               << "; Supported API version: "
-               << utils::gc_version_to_string(supported_api_v_)
-               << "; Recieved: "
-               << utils::gc_version_to_string(lib_v->api_version);
+               << "; Supported API version: " << supported_api_v_
+               << "; Recieved: " << lib_v->api_version;
             throw std::runtime_error(ss.str());
         }
 
@@ -120,8 +118,7 @@ graph_compiler_loader::~graph_compiler_loader() {
     dnnl::impl::graph::elyzor::graph_compiler_loader::get_vtable().fn_name( \
             __VA_ARGS__);
 
-const dnnl_graph_compiler_version *dnnl_graph_compiler_get_version(
-        void) {
+const dnnl_graph_compiler_version *dnnl_graph_compiler_get_version(void) {
     return LOAD_AND_CALL(dnnl_graph_compiler_get_version);
 }
 

--- a/src/graph/backend/elyzor/compiler_loader.cpp
+++ b/src/graph/backend/elyzor/compiler_loader.cpp
@@ -51,6 +51,17 @@ func_ptr_type load_func(void *handle, const char *func_name) {
     return func;
 }
 
+const dnnl_graph_compiler_version::version
+        graph_compiler_loader::supported_api_v_ {DNNL_GC_API_V_MAJOR,
+                DNNL_GC_API_V_MINOR, DNNL_GC_API_V_PATCH, .hash = ""};
+
+bool graph_compiler_loader::is_supported_api_version(
+        const dnnl_graph_compiler_version::version &api_v) {
+    return api_v.major == supported_api_v_.major
+            && api_v.minor == supported_api_v_.minor
+            && api_v.patch == supported_api_v_.patch;
+}
+
 graph_compiler_loader::graph_compiler_loader() {
     handle_ = dlopen(DNNL_GC_LIB_NAME, RTLD_LAZY | RTLD_DEEPBIND);
     if (!handle_) {
@@ -60,6 +71,21 @@ graph_compiler_loader::graph_compiler_loader() {
     }
 
     try {
+        vtable_.dnnl_graph_compiler_get_version
+                = load_func<dnnl_graph_compiler_get_version_t>(
+                        handle_, "dnnl_graph_compiler_get_version");
+
+        auto lib_v = vtable_.dnnl_graph_compiler_get_version();
+        if (!is_supported_api_version(lib_v->api_version)) {
+            std::stringstream ss;
+            ss << "Unsupported GC API version found in " << DNNL_GC_LIB_NAME
+               << "; Supported API version: "
+               << utils::gc_version_to_string(supported_api_v_)
+               << "; Recieved: "
+               << utils::gc_version_to_string(lib_v->api_version);
+            throw std::runtime_error(ss.str());
+        }
+
         vtable_.dnnl_graph_compiler_create
                 = load_func<dnnl_graph_compiler_create_t>(
                         handle_, "dnnl_graph_compiler_create");
@@ -93,6 +119,11 @@ graph_compiler_loader::~graph_compiler_loader() {
 #define LOAD_AND_CALL(fn_name, ...) \
     dnnl::impl::graph::elyzor::graph_compiler_loader::get_vtable().fn_name( \
             __VA_ARGS__);
+
+DNNL_API const dnnl_graph_compiler_version *dnnl_graph_compiler_get_version(
+        void) {
+    return LOAD_AND_CALL(dnnl_graph_compiler_get_version);
+}
 
 DNNL_API dnnl_status_t dnnl_graph_compiler_create(
         const struct dnnl_graph_compiler_context *ctx,

--- a/src/graph/backend/elyzor/compiler_loader.hpp
+++ b/src/graph/backend/elyzor/compiler_loader.hpp
@@ -25,6 +25,9 @@ namespace impl {
 namespace graph {
 namespace elyzor {
 
+typedef const dnnl_graph_compiler_version *(*dnnl_graph_compiler_get_version_t)(
+        void);
+
 typedef dnnl_status_t (*dnnl_graph_compiler_create_t)(
         const struct dnnl_graph_compiler_context *ctx,
         const struct dnnl_graph_compiler **gc);
@@ -47,6 +50,7 @@ typedef dnnl_status_t (*dnnl_graph_compiler_execute_t)(
         dnnl_graph_compiler_tensor *outputs);
 
 struct dnnl_graph_compiler_vtable {
+    dnnl_graph_compiler_get_version_t dnnl_graph_compiler_get_version;
     dnnl_graph_compiler_create_t dnnl_graph_compiler_create;
     dnnl_graph_compiler_destroy_t dnnl_graph_compiler_destroy;
     dnnl_graph_compiler_compile_t dnnl_graph_compiler_compile;
@@ -62,6 +66,8 @@ public:
         return ins.vtable_;
     }
     ~graph_compiler_loader();
+    static bool is_supported_api_version(
+            const dnnl_graph_compiler_version::version &api_v);
 
 private:
     graph_compiler_loader();
@@ -72,6 +78,7 @@ private:
 
     void *handle_;
     dnnl_graph_compiler_vtable vtable_;
+    static const dnnl_graph_compiler_version::version supported_api_v_;
 };
 
 } // namespace elyzor

--- a/src/graph/backend/elyzor/utils.cpp
+++ b/src/graph/backend/elyzor/utils.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  *******************************************************************************/
 #include "utils.hpp"
+#include <sstream>
 
 namespace dnnl {
 namespace impl {
@@ -93,6 +94,23 @@ std::vector<op_kind_t> get_supported_op_kinds() {
         ret.emplace_back(pair.first);
     }
     return ret;
+}
+
+std::string gc_version_to_string(const dnnl_graph_compiler_version &v) {
+    std::stringstream ss;
+    ss << "API version:\n\t" << gc_version_to_string(v.api_version)
+       << "\nGC version:\n\t" << gc_version_to_string(v.gc_version);
+    return ss.str();
+}
+
+std::string gc_version_to_string(
+        const dnnl_graph_compiler_version::version &v) {
+    std::stringstream ss;
+    // Cast uint8_t to int before inserting into the stringstream
+    // as otherwise they're interpreted as characters
+    ss << static_cast<int>(v.major) << "." << static_cast<int>(v.minor) << "."
+       << static_cast<int>(v.patch) << " " << v.hash;
+    return ss.str();
 }
 
 } // namespace utils

--- a/src/graph/backend/elyzor/utils.cpp
+++ b/src/graph/backend/elyzor/utils.cpp
@@ -96,25 +96,24 @@ std::vector<op_kind_t> get_supported_op_kinds() {
     return ret;
 }
 
-std::string gc_version_to_string(const dnnl_graph_compiler_version &v) {
-    std::stringstream ss;
-    ss << "API version:\n\t" << gc_version_to_string(v.api_version)
-       << "\nGC version:\n\t" << gc_version_to_string(v.gc_version);
-    return ss.str();
-}
-
-std::string gc_version_to_string(
-        const dnnl_graph_compiler_version::version &v) {
-    std::stringstream ss;
-    // Cast uint8_t to int before inserting into the stringstream
-    // as otherwise they're interpreted as characters
-    ss << static_cast<int>(v.major) << "." << static_cast<int>(v.minor) << "."
-       << static_cast<int>(v.patch) << " " << v.hash;
-    return ss.str();
-}
-
 } // namespace utils
 } // namespace elyzor
 } // namespace graph
 } // namespace impl
 } // namespace dnnl
+
+std::ostream &operator<<(
+        std::ostream &os, const dnnl_graph_compiler_version &v) {
+    os << "API version:\n\t" << v.api_version << "\nGC version:\n\t"
+       << v.gc_version;
+    return os;
+}
+
+std::ostream &operator<<(
+        std::ostream &os, const dnnl_graph_compiler_version::version &v) {
+    // Cast uint8_t to int before inserting into the stringstream
+    // as otherwise they're interpreted as characters
+    os << static_cast<int>(v.major) << "." << static_cast<int>(v.minor) << "."
+       << static_cast<int>(v.patch) << " " << v.hash;
+    return os;
+}

--- a/src/graph/backend/elyzor/utils.hpp
+++ b/src/graph/backend/elyzor/utils.hpp
@@ -60,8 +60,6 @@ inline dims get_dense_strides(const dims &shape) {
     return strides;
 }
 
-std::string gc_version_to_string(const dnnl_graph_compiler_version &v);
-std::string gc_version_to_string(const dnnl_graph_compiler_version::version &v);
 const std::unordered_map<op_kind_t, std::string, enum_hash_t> &
 get_supported_ops();
 std::vector<op_kind_t> get_supported_op_kinds();
@@ -81,4 +79,10 @@ std::vector<op_kind_t> get_supported_op_kinds();
 } // namespace graph
 } // namespace impl
 } // namespace dnnl
+
+std::ostream &operator<<(
+        std::ostream &os, const dnnl_graph_compiler_version &v);
+std::ostream &operator<<(
+        std::ostream &os, const dnnl_graph_compiler_version::version &v);
+
 #endif

--- a/src/graph/backend/elyzor/utils.hpp
+++ b/src/graph/backend/elyzor/utils.hpp
@@ -22,6 +22,7 @@
 #include <vector>
 #include <unordered_map>
 
+#include "include/dnnl_graph_compiler.h"
 #include <graph/interface/c_types_map.hpp>
 
 namespace dnnl {
@@ -59,6 +60,8 @@ inline dims get_dense_strides(const dims &shape) {
     return strides;
 }
 
+std::string gc_version_to_string(const dnnl_graph_compiler_version &v);
+std::string gc_version_to_string(const dnnl_graph_compiler_version::version &v);
 const std::unordered_map<op_kind_t, std::string, enum_hash_t> &
 get_supported_ops();
 std::vector<op_kind_t> get_supported_op_kinds();


### PR DESCRIPTION
What this PR does:
1. Adds the version getter (`dnnl_graph_compiler_get_version`) to the vtable `dnnl_graph_compiler_vtable`
2. During `libgraph_compiler.so` loading, verifies that the API version in the `.so` matches the one defined by oneDNN