### PR TITLE
graph: backend: elyzor: do not mark GC API as DNNL_API

### DIFF
--- a/src/graph/backend/elyzor/compiler_loader.cpp
+++ b/src/graph/backend/elyzor/compiler_loader.cpp
@@ -94,31 +94,29 @@ graph_compiler_loader::~graph_compiler_loader() {
     dnnl::impl::graph::elyzor::graph_compiler_loader::get_vtable().fn_name( \
             __VA_ARGS__);
 
-DNNL_API dnnl_status_t dnnl_graph_compiler_create(
+dnnl_status_t dnnl_graph_compiler_create(
         const struct dnnl_graph_compiler_context *ctx,
         const struct dnnl_graph_compiler **gc) {
     return LOAD_AND_CALL(dnnl_graph_compiler_create, ctx, gc);
 }
 
-DNNL_API void dnnl_graph_compiler_destroy(
-        const struct dnnl_graph_compiler *gc) {
+void dnnl_graph_compiler_destroy(const struct dnnl_graph_compiler *gc) {
     return LOAD_AND_CALL(dnnl_graph_compiler_destroy, gc);
 }
 
-DNNL_API dnnl_status_t dnnl_graph_compiler_compile(
-        const struct dnnl_graph_compiler *gc, const char *graph_json,
+dnnl_status_t dnnl_graph_compiler_compile(const struct dnnl_graph_compiler *gc,
+        const char *graph_json,
         const struct dnnl_graph_compiler_executable **exe) {
     return LOAD_AND_CALL(dnnl_graph_compiler_compile, gc, graph_json, exe);
 }
 
-DNNL_API void dnnl_graph_compiler_destroy_executable(
+void dnnl_graph_compiler_destroy_executable(
         const struct dnnl_graph_compiler *gc,
         const struct dnnl_graph_compiler_executable *exe) {
     LOAD_AND_CALL(dnnl_graph_compiler_destroy_executable, gc, exe);
 }
 
-DNNL_API dnnl_status_t dnnl_graph_compiler_execute(
-        const struct dnnl_graph_compiler *gc,
+dnnl_status_t dnnl_graph_compiler_execute(const struct dnnl_graph_compiler *gc,
         const struct dnnl_graph_compiler_executable *exe,
         dnnl_graph_compiler_tensor *inputs,
         dnnl_graph_compiler_tensor *outputs) {

--- a/src/graph/backend/elyzor/include/dnnl_graph_compiler.h
+++ b/src/graph/backend/elyzor/include/dnnl_graph_compiler.h
@@ -1,7 +1,5 @@
 #ifndef DNNL_GRAPH_COMPILER_H
 #define DNNL_GRAPH_COMPILER_H
-#define DNNL_DLL
-#define DNNL_DLL_EXPORTS
 
 #include <cstddef>
 #include <cstdint>
@@ -66,25 +64,23 @@ struct dnnl_graph_compiler_tensor {
     void *data;
 };
 
-DNNL_API const dnnl_graph_compiler_version *dnnl_graph_compiler_get_version(
-        void);
+const dnnl_graph_compiler_version *dnnl_graph_compiler_get_version(void);
 
-DNNL_API dnnl_status_t dnnl_graph_compiler_create(
+dnnl_status_t dnnl_graph_compiler_create(
         const struct dnnl_graph_compiler_context *ctx,
         const struct dnnl_graph_compiler **gc);
 
-DNNL_API void dnnl_graph_compiler_destroy(const struct dnnl_graph_compiler *gc);
+void dnnl_graph_compiler_destroy(const struct dnnl_graph_compiler *gc);
 
-DNNL_API dnnl_status_t dnnl_graph_compiler_compile(
-        const struct dnnl_graph_compiler *gc, const char *graph_json,
+dnnl_status_t dnnl_graph_compiler_compile(const struct dnnl_graph_compiler *gc,
+        const char *graph_json,
         const struct dnnl_graph_compiler_executable **exe);
 
-DNNL_API void dnnl_graph_compiler_destroy_executable(
+void dnnl_graph_compiler_destroy_executable(
         const struct dnnl_graph_compiler *gc,
         const struct dnnl_graph_compiler_executable *exe);
 
-DNNL_API dnnl_status_t dnnl_graph_compiler_execute(
-        const struct dnnl_graph_compiler *gc,
+dnnl_status_t dnnl_graph_compiler_execute(const struct dnnl_graph_compiler *gc,
         const struct dnnl_graph_compiler_executable *exe,
         dnnl_graph_compiler_tensor *inputs,
         dnnl_graph_compiler_tensor *outputs);


### PR DESCRIPTION
This PR removes `DNNL_API` attribute for GC API functions.

<b>Why removing?</b>
`DNNL_API` makes [implementations in `compiler_loader.cpp`](https://github.com/kurapov-peter/oneDNN/blob/9a5d090074c44de4982955a20c2b5ff94efad6fd/src/graph/backend/elyzor/compiler_loader.cpp#L97) visible to the users of `libdnnl.so` which is undesired.

<b>Why was it there in the first place?</b>
This was made so the visibility attributes would automatically propagate to the implementations in graph compiler and make them visible in `libgraph_compiler.so`, this however causes the implementations in oneDNN to be visible too. So it was decided to remove the `DNNL_API` attribute in the API header and add the visibility attribute only for the implementations in graph compiler.

